### PR TITLE
feat: make attention required message nullable

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Entity/IpnOrders.php
+++ b/src/Orderly/PayPalIpnBundle/Entity/IpnOrders.php
@@ -698,7 +698,7 @@ class IpnOrders
     /**
      * @var string $attentionRequiredMessage
      *
-     * @ORM\Column(name="attention_required_message", type="string", length=255, nullable=false)
+     * @ORM\Column(name="attention_required_message", type="string", length=255, nullable=true)
      */
     private $attentionRequiredMessage;
 


### PR DESCRIPTION
During functional tests of Paypal integration for 👕 an issue came up that `attention required message` is returned as null, but the code doesn't support that. I manually changed migrations in 👕  so the field is nullable. This PR gets it done the right way.  I wonder how it's resolved in 👢 @oantonelli ? Attention required message from logical point of view should be nullable, not every transaction is marked as attention required. 