### PR TITLE
feat: add yml route

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Controller/NoNotificationController.php
+++ b/src/Orderly/PayPalIpnBundle/Controller/NoNotificationController.php
@@ -31,10 +31,6 @@ class NoNotificationController extends Controller
 
     public $paypal_ipn;
 
-    /**
-     * @Route("/ipn-no-notification")
-     * @Template()
-     */
     public function indexAction()
     {
         //getting ipn service registered in container

--- a/src/Orderly/PayPalIpnBundle/Resources/config/routing.yml
+++ b/src/Orderly/PayPalIpnBundle/Resources/config/routing.yml
@@ -1,0 +1,3 @@
+IpnNoNotification:
+   path: /ipn-no-notification
+   defaults: { _controller: OrderlyPayPalIpnBundle:NoNotification:index }


### PR DESCRIPTION
```
In AnnotationException.php line 54:
                                                                               
  [Doctrine\Common\Annotations\AnnotationException]                            
  [Semantical Error] The annotation "@Route" in method Orderly\PayPalIpnBundl  
  e\Controller\NoNotificationController::indexAction() was never imported. 
```