### PR TITLE
build: make framework extra bundle a dev dependency (as annotations are opt-in) and allow newer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
   "require": {
     "php": ">=7.1",
     "symfony/framework-bundle": "^3.4",
-    "sensio/framework-extra-bundle": "^3.0",
     "doctrine/orm": "^2.6",
     "doctrine/persistence": "^1.3"
   },
   "require-dev": {
     "phpstan/phpstan": "^0.6.0",
+    "sensio/framework-extra-bundle": "^3|^4|^5",
     "squizlabs/php_codesniffer": "~3.0.0"
   },
   "autoload": {


### PR DESCRIPTION
We're only using annotations in the bundle (and even then, I imagine optionally) so the framework extra bundle need only be a dev dependency. We also aren't using the annotations in a version-specific way, so we should allow newer versions of that bundle. (This also, importantly, means that applications including this package are free to use whichever version of the framework extra bundle they need including ones dedicated to more recent versions of PHP and Symfony.)